### PR TITLE
remove bitwise operations from float/int checks

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,8 +4,6 @@
   "rules": {
     "global-strict": 0,
     "max-len": 0,
-    // FIXME: Refactor and remove this rule
-    "no-bitwise": 1,
     "strict": 1
   },
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -95,7 +95,7 @@ function convert(key, value) {
  */
 
 function isFloat(n) {
-  return n === +n && n !== (n | 0);
+  return is.number(n) && Math.floor(n) !== n;
 }
 
 /**
@@ -103,5 +103,5 @@ function isFloat(n) {
  */
 
 function isInt(n) {
-  return n === +n && n === (n | 0);
+  return is.number(n) && Math.floor(n) === n;
 }


### PR DESCRIPTION
Purely stylistic, so we can remove the `no-bitwise` exemption from `eslintrc`

**note**: _both_ the outgoing and new implementations fail to parse `2.0` as a float...

``` js
javascript === javascript // ¯\_(ツ)_/¯
```
