### PR TITLE
Fix test infrastructure

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "extends": "segment/browser",
+  "extends": "@segment/eslint-config/browser/legacy",
 
   "rules": {
     "global-strict": 0,

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 build.js
 components
 node_modules
+coverage

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ TESTS = $(shell find $(TESTS_DIR) -type f -name '*.test.js')
 # Task config.
 #
 KARMA_FLAGS ?= 
-BROWSERS ?= chrome
+BROWSERS ?= Chrome
 
 KARMA_CONF = karma.conf.js
 
@@ -35,12 +35,12 @@ node_modules: package.json $(wildcard node_modules/*/package.json)
 
 # Remove temporary files and build artifacts.
 clean:
-	rm -rf build.js
+	rm -rf coverage
 .PHONY: clean
 
 # Remove temporary files, build artifacts, and vendor dependencies.
 distclean: clean
-	rm -rf components node_modules
+	rm -rf node_modules
 .PHONY: distclean
 
 #
@@ -61,12 +61,12 @@ lint: node_modules
 
 # Test locally in PhantomJS.
 test-phantomjs: node_modules
-	$(KARMA) start $(KARMA_FLAGS) --browser PhantomJS $(KARMA_CONF) --single-run
+	$(KARMA) start $(KARMA_FLAGS) --browsers PhantomJS $(KARMA_CONF) --single-run
 .PHONY: test
 
 # Test locally in the browser.
 test-browser: node_modules
-	$(KARMA) start $(KARMA_FLAGS) --browser $(BROWSERS) $(KARMA_CONF)
+	$(KARMA) start $(KARMA_FLAGS) --browsers $(BROWSERS) $(KARMA_CONF)
 .PHONY: test-browser
 
 # Test shortcut.

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 0.12
+    version: 6
 dependencies:
   pre:
     - echo "github.com,192.30.252.*,192.30.253.*,192.30.254.*,192.30.255.* ssh-rsa $(ssh-keyscan -t rsa github.com | cut -d ' ' -f 3-)" >> ~/.ssh/known_hosts

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,50 @@
+/* eslint-env node */
+'use strict';
+
+module.exports = function(config) {
+  config.set({
+    files: [
+      'test/**/*.test.js'
+    ],
+
+    browsers: ['PhantomJS'],
+
+    frameworks: ['browserify', 'mocha'],
+
+    reporters: ['spec', 'coverage'],
+
+    preprocessors: {
+      'test/**/*.js': 'browserify'
+    },
+
+    client: {
+      mocha: {
+        grep: process.env.GREP,
+        reporter: 'html',
+        timeout: 10000
+      }
+    },
+
+    browserify: {
+      debug: true,
+      transform: [
+        [
+          'browserify-istanbul',
+          {
+            instrumenterConfig: {
+              embedSource: true
+            }
+          }
+        ]
+      ]
+    },
+
+    coverageReporter: {
+      reporters: [
+        { type: 'text' },
+        { type: 'html' },
+        { type: 'json' }
+      ]
+    }
+  });
+};

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -7,7 +7,7 @@ module.exports = function(config) {
       'test/**/*.test.js'
     ],
 
-    browsers: ['PhantomJS'],
+    browsers: ['PhantomJS', 'Chrome'],
 
     frameworks: ['browserify', 'mocha'],
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,8 +4,8 @@
  */
 
 var camel = require('to-camel-case');
-var foldl = require('foldl');
-var integration = require('analytics.js-integration');
+var foldl = require('@ndhoule/foldl');
+var integration = require('@segment/analytics.js-integration');
 var is = require('is');
 
 /**
@@ -101,7 +101,7 @@ function convert(key, value) {
   if (isInt(value)) return key + '_int';
   if (isFloat(value)) return key + '_real';
   if (is.date(value)) return key + '_date';
-  if (is.boolean(value)) return key + '_bool';
+  if (is.bool(value)) return key + '_bool';
   return key;  // Bad FullStory type, but don't mess with the key so error messages name it
 }
 

--- a/package.json
+++ b/package.json
@@ -1,32 +1,47 @@
 {
-  "name": "analytics.js-integration-fullstory",
+  "name": "@segment/analytics.js-integration-fullstory",
   "description": "The Fullstory analytics.js integration.",
-  "author": "Segment <friends@segment.com>",
+  "author": "FullStory <support@fullstory.com>",
   "license": "MIT",
   "main": "lib/index.js",
   "scripts": {
     "test": "make test"
   },
-  "engines": {
-    "node": ">=0.12.0",
-    "npm": ">=2.7.0"
-  },
   "repository": {
-    "url": "https://github.com/segment-integrations/analytics.js-integration-fullstory.git",
+    "url": "git+https://github.com/fullstorydev/analytics.js-integration-fullstory.git",
     "type": "git"
   },
   "bugs": {
-    "url": "https://github.com/segment-integrations/analytics.js-integration-fullstory/issues"
+    "url": "https://github.com/fullstorydev/analytics.js-integration-fullstory/issues"
   },
   "homepage": "https://segment.com/docs/integrations/fullstory/",
-  "dependencies": {},
+  "dependencies": {
+    "is": "^3.2",
+    "to-camel-case": "^1.0",
+    "@ndhoule/foldl": "^2.0.1",
+    "@segment/analytics.js-integration": "^2.1.0"
+  },
   "devDependencies": {
-    "duo": "0.12.x",
-    "duo-test": "0.2.x",
-    "eslint": "0.x",
-    "eslint-config-segment": "^1.0.10",
+    "@segment/analytics.js-core": "^3.0.0",
+    "@segment/analytics.js-integration-tester": "^2.0.0",
+    "@segment/clear-env": "^2.0.0",
+    "@segment/eslint-config": "^3.1.1",
+    "browserify": "^13.0.0",
+    "browserify-istanbul": "^2.0.0",
+    "eslint": "^2.9.0",
+    "eslint-plugin-mocha": "^2.2.0",
+    "eslint-plugin-require-path-exists": "^1.1.5",
+    "eslint-plugin-react": "^4.0.0",
+    "istanbul": "^0.4.3",
+    "karma": "^1.3",
+    "karma-browserify": "^5.1",
+    "karma-chrome-launcher": "^2.0",
+    "karma-coverage": "^1.1",
+    "karma-mocha": "^1.3",
+    "karma-phantomjs-launcher": "^1.0",
+    "karma-spec-reporter": "0.0.26",
     "mocha": "^2.2.5",
-    "mocha-phantomjs": "segmentio/mocha-phantomjs#master",
-    "phantomjs": "^1.9.17"
+    "phantomjs-prebuilt": "^2.1.7",
+    "watchify": "^3.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@segment/analytics.js-integration-fullstory",
+  "name": "analytics.js-integration-fullstory",
   "description": "The Fullstory analytics.js integration.",
   "author": "FullStory <support@fullstory.com>",
   "license": "MIT",

--- a/test/index.html
+++ b/test/index.html
@@ -6,7 +6,7 @@
   </head>
   <body>
     <div id="mocha"></div>
-    <script src="/saucelabs.js"></script>
+    <!-- <script src="/saucelabs.js"></script> -->
     <script src="/node_modules/mocha/mocha.js"></script>
     <script>
       mocha.setup({

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,8 +1,8 @@
 
-var Analytics = require('analytics.js-core').constructor;
-var integration = require('analytics.js-integration');
-var sandbox = require('clear-env');
-var tester = require('analytics.js-integration-tester');
+var Analytics = require('@segment/analytics.js-core').constructor;
+var integration = require('@segment/analytics.js-integration');
+var sandbox = require('@segment/clear-env');
+var tester = require('@segment/analytics.js-integration-tester');
 var FullStory = require('../lib/');
 
 describe('FullStory', function() {
@@ -135,12 +135,12 @@ describe('FullStory', function() {
         analytics.identify('id3', { my_real: 17, my_int_str: 17, my_str_int: 'foo', my_int_date: 3,
                my_int_bool: 4, mystr_real: 'plugh' });
         analytics.called(window.FS.identify, 'id3', {
-               my_real: 17,      // didn't become my_real_real (double tag)
-               myInt_str: 17,    // all other tests check type mismatch isn't
-               myStr_int: 'foo', // "fixed" to e.g. myInt_str_int, but keeps
-               myInt_date: 3,    // the user's tag (and their mismatch error)
-               myInt_bool: 4,
-               mystr_real: 'plugh' });
+          my_real: 17,      // didn't become my_real_real (double tag)
+          myInt_str: 17,    // all other tests check type mismatch isn't
+          myStr_int: 'foo', // "fixed" to e.g. myInt_str_int, but keeps
+          myInt_date: 3,    // the user's tag (and their mismatch error)
+          myInt_bool: 4,
+          mystr_real: 'plugh' });
       });
     });
   });


### PR DESCRIPTION
The duo-based tests here were bitrotted, and I wasn't even able to get them to play nice with version dependencies.  Besides which, I'd NEVER been able to get all the variations to play nice.

So, this replaces them with a Karma-based system, heavily cribbed from what the Optimizely integration did in https://github.com/segment-integrations/analytics.js-integration-optimizely/commit/7bfcb4a7018bba95ecf32536f78862f132e47132, which will hopefully be... if not MORE stable, then at least more known-to-us (as opposed to what we inherited from Segment) and thus more maintainable.

No functionality changes here, but a pretty complete reimplementation of the Makefile and its targets.