### PR TITLE
Don't pass object types FullStory can't swallow

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -63,6 +63,9 @@ FullStory.prototype.identify = function(identify) {
   var traits = identify.traits({ name: 'displayName' });
 
   var newTraits = foldl(function(results, value, key) {
+    if (typeof(value) == "object" && value.constructor != Date) {
+      return results;
+    }
     if (key !== 'id') results[key === 'displayName' || key === 'email' ? key : convert(key, value)] = value;
     return results;
   }, {}, traits);

--- a/lib/index.js
+++ b/lib/index.js
@@ -63,7 +63,7 @@ FullStory.prototype.identify = function(identify) {
   var traits = identify.traits({ name: 'displayName' });
 
   var newTraits = foldl(function(results, value, key) {
-    if (typeof(value) == "object" && value.constructor != Date) {
+    if (typeof value === 'object' && value.constructor !== Date) {
       return results;
     }
     if (key !== 'id') results[key === 'displayName' || key === 'email' ? key : convert(key, value)] = value;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -121,14 +121,14 @@ describe('FullStory', function() {
         analytics.called(window.FS.identify, 'id3', { displayName: 'Steven', registered_bool: true });
       });
 
-      it('should pass arrays through un-tagged', function() {
-        analytics.identify('id3', { teams: ['eng', 'redsox'] });
-        analytics.called(window.FS.identify, 'id3', { teams: [ 'eng', 'redsox'] });
+      it('should skip arrays entirely', function() {
+        analytics.identify('id3', { ok: 'string', teams: ['eng', 'redsox'] });
+        analytics.called(window.FS.identify, 'id3', { ok_str: 'string' });
       });
 
-      it('should pass user objects through un-tagged', function() {
-        analytics.identify('id3', { account: { level: 'premier', avg_annual: 30000 } });
-        analytics.called(window.FS.identify, 'id3', { account: { level: 'premier', avg_annual: 30000 } });
+      it('should skip user objects entirely', function() {
+        analytics.identify('id3', { ok: 7, account: { level: 'premier', avg_annual: 30000 } });
+        analytics.called(window.FS.identify, 'id3', { ok_int: 7 );
       });
 
       it('should respect existing type tags', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -128,7 +128,7 @@ describe('FullStory', function() {
 
       it('should skip user objects entirely', function() {
         analytics.identify('id3', { ok: 7, account: { level: 'premier', avg_annual: 30000 } });
-        analytics.called(window.FS.identify, 'id3', { ok_int: 7 );
+        analytics.called(window.FS.identify, 'id3', { ok_int: 7 });
       });
 
       it('should respect existing type tags', function() {


### PR DESCRIPTION
See also https://github.com/fullstorydev/analytics.js-integration-fullstory/pull/9, which is a prerequisite to get the tests back up and running.

But this change here is about NOT passing compound types (objects and arrays) through Segment to FullStory.  We had, originally, deliberately passed everything, figuring that people should know if they sent an invalid thing.  However, it turns out that they do it All.  The.  Time.  This because Segment encourages it (for example, for "address" traits, see https://segment.com/docs/spec/identify/), and other tools do also (in particular, several of our customers use a "company" object, to hold what we would think of as account variables).

So, since it's common and it creates spam that users are going to ignore instead of "fixing" (because it's not broken to their other tools), let's just be quiet, shall we?